### PR TITLE
feat: force delete ECS resources

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -1,5 +1,6 @@
 resource "aws_ecs_cluster" "this" {
-  name = "${var.project_name}-cluster"
+  name         = "${var.project_name}-cluster"
+  force_delete = true
 }
 
 resource "aws_cloudwatch_log_group" "app" {
@@ -51,6 +52,7 @@ resource "aws_ecs_service" "app" {
   task_definition = aws_ecs_task_definition.app.arn
   desired_count   = 1
   launch_type     = "FARGATE"
+  force_delete    = true
 
   network_configuration {
     subnets          = [for s in aws_subnet.public : s.id]


### PR DESCRIPTION
## Summary
- allow ECS cluster deletion even if services exist
- force delete ECS service when tasks remain

## Testing
- `terraform fmt -recursive`
- `terraform validate` *(fails: could not retrieve provider packages)*

------
https://chatgpt.com/codex/tasks/task_e_689bb0150060832d82796639c05b9751