### PR TITLE
Remove force delete flag from ECS cluster

### DIFF
--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -1,6 +1,5 @@
 resource "aws_ecs_cluster" "this" {
   name         = "${var.project_name}-cluster"
-  force_delete = true
 }
 
 resource "aws_cloudwatch_log_group" "app" {


### PR DESCRIPTION
## Summary
- remove `force_delete` flag from ECS cluster definition

## Testing
- `terraform init` *(fails: No valid credential sources found)*
- `terraform plan` *(fails: Backend initialization required, please run "terraform init")*


------
https://chatgpt.com/codex/tasks/task_e_689bb72e5ed0832db28b8d1e8a758b67