### PR TITLE
Add simple inventory frontend

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Inventario</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        table { border-collapse: collapse; width: 50%; }
+        th, td { border: 1px solid #ccc; padding: 0.5em; text-align: left; }
+        th { background-color: #f0f0f0; }
+        form { margin-bottom: 1em; }
+    </style>
+</head>
+<body>
+    <h1>Inventario</h1>
+    <form id="item-form">
+        <input type="text" id="name" placeholder="Nombre" required />
+        <input type="number" id="quantity" placeholder="Cantidad" value="0" min="0" />
+        <button type="submit">Agregar</button>
+    </form>
+    <table>
+        <thead>
+            <tr><th>ID</th><th>Nombre</th><th>Cantidad</th></tr>
+        </thead>
+        <tbody id="items-body"></tbody>
+    </table>
+    <script>
+    async function loadItems() {
+        const res = await fetch('/items');
+        const data = await res.json();
+        const tbody = document.getElementById('items-body');
+        tbody.innerHTML = '';
+        data.forEach(item => {
+            const row = document.createElement('tr');
+            row.innerHTML = `<td>${item.id}</td><td>${item.name}</td><td>${item.quantity}</td>`;
+            tbody.appendChild(row);
+        });
+    }
+    document.getElementById('item-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const name = document.getElementById('name').value;
+        const quantity = parseInt(document.getElementById('quantity').value, 10) || 0;
+        await fetch('/items', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, quantity })
+        });
+        document.getElementById('name').value = '';
+        document.getElementById('quantity').value = '0';
+        loadItems();
+    });
+    loadItems();
+    </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add inventory table and endpoints
- serve simple HTML interface for managing items

## Testing
- `python -m py_compile app/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bcba33334832daa2b927710bf7630