### PR TITLE
Add Bash script to get ECS service IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,21 @@
    db_password  = "<seguro>"
    db_name      = "appdb"
    ```
+
+## Obtener la URL del servicio
+
+Una vez que la tarea ECS esté corriendo, puedes consultar la IP pública del contenedor con:
+
+Linux/macOS:
+
+```bash
+./scripts/get_service_public_ip.sh <cluster-name> <service-name> [region]
+```
+
+Windows PowerShell:
+
+```powershell
+pwsh scripts/get_service_public_ip.ps1 -ClusterName <cluster-name> -ServiceName <service-name> [-Region us-east-1]
+```
+
+Ambos scripts imprimen `http://<public-ip>/`.

--- a/scripts/get_service_public_ip.sh
+++ b/scripts/get_service_public_ip.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo "Usage: $0 <cluster-name> <service-name> [region]" >&2
+  exit 1
+fi
+
+cluster_name="$1"
+service_name="$2"
+region="${3:-us-east-1}"
+
+task_arn=$(aws ecs list-tasks --cluster "$cluster_name" --service-name "$service_name" --region "$region" --query 'taskArns[0]' --output text)
+if [[ -z "$task_arn" || "$task_arn" == "None" ]]; then
+  echo "No running tasks found for service '$service_name' in cluster '$cluster_name'" >&2
+  exit 1
+fi
+
+eni_id=$(aws ecs describe-tasks --tasks "$task_arn" --cluster "$cluster_name" --region "$region" --query 'tasks[0].attachments[0].details[?name==`networkInterfaceId`].value' --output text)
+if [[ -z "$eni_id" || "$eni_id" == "None" ]]; then
+  echo "No ENI found for task $task_arn (task may still be starting)" >&2
+  exit 1
+fi
+
+public_ip=$(aws ec2 describe-network-interfaces --network-interface-ids "$eni_id" --region "$region" --query 'NetworkInterfaces[0].Association.PublicIp' --output text)
+if [[ -z "$public_ip" || "$public_ip" == "None" ]]; then
+  echo "No public IP associated with ENI $eni_id (wait a minute and retry)" >&2
+  exit 2
+fi
+
+echo "http://$public_ip/"


### PR DESCRIPTION
## Summary
- add Bash helper script to query ECS task's public IP
- document public IP retrieval for Bash and PowerShell users

## Testing
- `bash -n scripts/get_service_public_ip.sh`
- `./scripts/get_service_public_ip.sh` *(fails: Usage: ./scripts/get_service_public_ip.sh <cluster-name> <service-name> [region])*

------
https://chatgpt.com/codex/tasks/task_e_689be0e7fd28832d963e0bf6643a05e1